### PR TITLE
스플릿 대체

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,9 +15,19 @@ fn get_random_number() -> [u8; 4] {
  * Parse input
  */
 fn parse_input(input: &String) -> Vec<u8> {
+    /*
     let nums: Vec<u8> = input.split_whitespace()
     .map(|s| s.parse().expect("Invalid Input"))
     .collect();
+    */
+    let mut nums: Vec<u8> = vec!();
+
+    for i in input.trim().chars()
+    {
+        let c = i as u8;
+        nums.push(c - 48);
+    }
+    
     nums
 }
 


### PR DESCRIPTION
기존 코드에서 입력을 3 4 5 6 이렇게 공백을 포함해줘야 parse_input이 작동하였다.
실제로 플레이 했을 때, 숫자를 입력할 때 공백을 입력하지 않는 것이 플레이어에게 익숙할 수 있다는 생각이 들었다.